### PR TITLE
Adicionando template do README.md

### DIFF
--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -1,0 +1,14 @@
+Configurações
+
+ - Editar o `.github/CODEOWNERS` e deixar apenas os times relevantes para o projeto
+ - Entrar no CircleCi e ativar os builds para esse projeto
+ - Conferir que os dados foram enviados ao codecov.io
+
+# Nome do Projeto
+
+Descrição breve sobre o projeto
+
+# Como rodar o projeto
+
+
+# Como rodar os testes


### PR DESCRIPTION
A ideia é que quando formos usar esse boilerplate em algum projeto,
possamos jogar fora o README.md e usar o README.md.tmpl com base.

Vamos rever esse template e completar o que acharmos que está faltando.