### PR TITLE
Feature/use circleci contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
   node10x: &template
     docker:
       - image: circleci/node:10-jessie
-        auth:
-          username: $B2WADS_DOCKER_REGISTRY_USERNAME
-          password: $B2WADS_DOCKER_REGISTRY_PASSWORD
-        #- image: mongo:3.6
-        #- image: elasticsearch:5
-        #- image: rabbitmq:3.6-alpine
-        #- image: redis:5
+        #auth:
+          #username: $B2WADS_DOCKER_REGISTRY_USERNAME
+          #password: $B2WADS_DOCKER_REGISTRY_PASSWORD
+      #- image: mongo:3.6
+      #- image: elasticsearch:5
+      #- image: rabbitmq:3.6-alpine
+      #- image: redis:5
     steps:
       - checkout
       - run:
@@ -30,10 +30,16 @@ jobs:
       <<: *template
       docker:
         - image: circleci/node:11
-          #- image: mongo:3.6
-          #- image: elasticsearch:5
-          #- image: rabbitmq:3.6-alpine
-          #- image: redis:5
+        #- image: mongo:3.6
+        #- image: elasticsearch:5
+        #- image: rabbitmq:3.6-alpine
+        #- image: redis:5
+
+
+# O `context:` abaixo deve ser usado se você precisa
+# de uma imagem privada. Nesse context devem estar cadastradas as envs:
+# - B2WADS_DOCKER_REGISTRY_USERNAME
+# - B2WADS_DOCKER_REGISTRY_PASSWORD
 workflows:
   version: 2
   required-checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ workflows:
   version: 2
   required-checks:
     jobs:
-      - node10x
+      - node10x:
+          context: docker-registry-auth
   optional-checks:
     jobs:
-      - node11x
+      - node11x:
+          context: docker-registry-auth


### PR DESCRIPTION
É possível ter ENVs globais (para toda a org) no circleci. Fiz isso nesse PR. 

Criei o primeiro "grupo" de envs globais chamado `docker-registry-auth`. Qualquer projeto que precisar fazer pull de uma imagem privada nossa deve usar essa config de `context: ...` nos jobs que precisarem dessa autenticação.

E claro, descomentar o uso dessas duas envs em cada um das imagens docker onde essa auth for necessária.