### PR TITLE
fix: configurar test env como node

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = {testEnvironment: 'node', collectCoverage: true}
+module.exports = {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  bail: true
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = {testEnvironment: 'node', collectCoverage: true}

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "prettier": "./node_modules/.bin/prettier --write \"**/{*.js,*.json,bin/**}\"",
     "prettier:check": "./node_modules/.bin/prettier --check \"**/{*.js,*.json,bin/**}\"",
     "start": "node ./bin/www",
-    "test": "./node_modules/.bin/jest",
-    "test:acceptance": "./node_modules/.bin/jest test/acceptance/*",
-    "test:integration": "./node_modules/.bin/jest test/integration/*",
-    "test:unit": "./node_modules/.bin/jest test test/unit/*",
+    "test": "./node_modules/.bin/jest --runInBand --forceExit",
+    "test:acceptance": "./node_modules/.bin/jest --runInBand --forceExit test/acceptance/*",
+    "test:integration": "./node_modules/.bin/jest --runInBand --forceExit test/integration/*",
+    "test:unit": "./node_modules/.bin/jest --runInBand --forceExit test/unit/*",
     "worker:<worker-name>": "node worker/<worker-name.js>"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "prettier": "./node_modules/.bin/prettier --write \"**/{*.js,*.json,bin/**}\"",
     "prettier:check": "./node_modules/.bin/prettier --check \"**/{*.js,*.json,bin/**}\"",
     "start": "node ./bin/www",
-    "test": "./node_modules/.bin/jest --coverage",
-    "test:acceptance": "./node_modules/.bin/jest --coverage test/acceptance/*",
-    "test:integration": "./node_modules/.bin/jest --coverage test/integration/*",
-    "test:unit": "./node_modules/.bin/jest --coverage test test/unit/*",
+    "test": "./node_modules/.bin/jest",
+    "test:acceptance": "./node_modules/.bin/jest test/acceptance/*",
+    "test:integration": "./node_modules/.bin/jest test/integration/*",
+    "test:unit": "./node_modules/.bin/jest test test/unit/*",
     "worker:<worker-name>": "node worker/<worker-name.js>"
   },
   "repository": {


### PR DESCRIPTION
### Descrição

Cria um arquivo jest.config.js para setar o testEnvironment como "node", corrige erro que acontecia quando tentava acessar algumas funções do node (como setInterval(...).unref)