### PR TITLE
fix: remove regra 'arrow-parens' do eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
     "no-unsafe-regex/no-unsafe-regex": "error",
     "func-names": ["warn", "always", { "generators": "never" }],
     "no-underscore-dangle": "off",
-    "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
     "camelcase": [
       "error",
       {


### PR DESCRIPTION
### Descrição
 
Remove a regra "arrow-parens" do eslintrc para não conflitar com o prettier. O prettier requer que não haja parênteses quando houver apenas um parâmetro na arrow function, e essa regra do eslintrc requeria parênteses sempre que a arrow function for seguida d eum bloco ({...}), causando conflito quando os dois aconteciam.

A regra não é necessária já que o estilo configurado no prettier já trata de parênteses em arrow function.
