### PR TITLE
Benchmark de performance com profiling

### DIFF
--- a/benchmark/sqrt.js
+++ b/benchmark/sqrt.js
@@ -1,0 +1,18 @@
+const Benchmark = require('benchmark')
+const { benchmarkConfig } = require('../config')
+
+const benchmark = new Benchmark(
+  'test Sqrt',
+  () => {
+    for (let i = 0; i < 100000; i++) {
+      Math.sqrt(Math.random())
+    }
+  },
+  benchmarkConfig
+)
+
+benchmark.on('complete', function() {
+  console.log(this)
+})
+
+benchmark.run()

--- a/bin/run-benchmark.sh
+++ b/bin/run-benchmark.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+benchmarks_dir="tmp_benchmark_results"
+
+mkdir -p "$benchmarks_dir"
+
+bench_script=$1
+if [ "$bench_script" == "" ]; then
+  echo "please specify benchmark to be ran"
+fi
+
+cd "$benchmarks_dir"
+
+node \
+--prof \
+"../$bench_script"
+
+log_file=$(find ./ -regex ".*\.log$")
+
+cd ..
+
+benchmark_results=$(node --prof-process "$benchmarks_dir/$log_file")
+filtered_results=$(echo "$benchmark_results" | awk "/JavaScript/" RS= )
+echo "$filtered_results"
+
+rm "$benchmarks_dir/$log_file"
+rmdir "$benchmarks_dir"

--- a/config/benchmark.yaml
+++ b/config/benchmark.yaml
@@ -1,0 +1,8 @@
+defaults:
+  minSamples: 10
+  maxTime: 2
+  async: true
+test:
+  minSamples: env:BENCHMARK_MIN_SAMPLES
+  maxTime: env:BENCHMARK_MAX_TIME
+  async: env:BENCHMARK_ASYNC

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,17 @@
+const envLoader = require('env-o-loader')
+const fs = require('fs')
+
+// eslint-disable-next-line security/detect-non-literal-fs-filename
+const availableConfigs = fs
+  .readdirSync(__dirname)
+  .filter(
+    fileName =>
+      fileName.substring(fileName.length - 5, fileName.length) === '.yaml'
+  )
+  .reduce((acc, fileName) => {
+    const fileNameWithoutExtension = fileName.substring(0, fileName.length - 5)
+    // eslint-disable-next-line security/detect-object-injection
+    acc[`${fileNameWithoutExtension}Config`] = envLoader(`./${fileName}`)
+    return acc
+  }, {})
+module.exports = availableConfigs

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,7 +210,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -278,6 +277,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "body-parser": {
       "version": "1.19.0",
@@ -662,6 +671,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "env-o-loader": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/env-o-loader/-/env-o-loader-1.0.7.tgz",
+      "integrity": "sha512-2Z2nYKIMoW4j7oVriJmRyT+yxACpxPIanLdDIN9YO0vbbro/6PmCkweWZ6KEENkNVHd+V+ROqB1pTmParymb9w==",
+      "requires": {
+        "callsites": "^2.0.0",
+        "iso8601-duration": "^1.0.6",
+        "js-yaml": "^3.10.0",
+        "qs": "^6.5.0",
+        "underscore": "^1.8.3"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+        }
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1191,8 +1219,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1775,6 +1802,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "iso8601-duration": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-1.2.0.tgz",
+      "integrity": "sha512-ErTBd++b17E8nmWII1K1uZtBgD1E8RjyvwmxlCjPHNqHMD7gmcMHOw0E8Ro/6+QT4PhHRSnnMo7bxa1vFPkwhg=="
+    },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -1884,7 +1916,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2560,6 +2591,12 @@
         "find-up": "^3.0.0"
       }
     },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -2950,8 +2987,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "statuses": {
       "version": "1.5.0",
@@ -3208,6 +3244,11 @@
           "optional": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Boilerplate para projetos NodeJS",
   "main": "app.js",
   "dependencies": {
+    "env-o-loader": "^1.0.7",
     "express": "4.17.0"
   },
   "devDependencies": {
     "acorn": "^7.1.0",
+    "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "eslint": "6.2.2",
     "eslint-config-airbnb": "18.0.1",
@@ -40,7 +42,8 @@
     "test:acceptance": "npm t test/acceptance/*",
     "test:integration": "npm t test/integration/*",
     "test:unit": "npm t test/unit/*",
-    "worker:<worker-name>": "node workers/<worker-name.js>"
+    "worker:<worker-name>": "node workers/<worker-name.js>",
+    "benchmark": "./bin/run-benchmark.sh ./benchmark/sqrt.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Descrição

Com a ideia de testar a performance das aplicações surge a necessidade de se visualizar métricas mais detalhadas de maneira a serem tomadas decisões mais assertivas sobre otimizações a nível de código.
Nesse PR adicionei ao projeto a mesma lib de benchmarks utilizada nos testes de performance do [V8](https://github.com/v8/web-tooling-benchmark) e adicionei um script que extrai informações do [profiler padrão do Node.js](https://nodejs.org/en/docs/guides/simple-profiling/)

Atualmente é somente uma versão para podermos começar a ver o ferramental em funcionamento, somente é capaz de executar um benchmark por vez.

Para executar basta utilizar o comando ```npm run benchmark```
