### PR TITLE
Adicionar extensões de arquivos temporários aos ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ typings/
 
 # IDE
 .vscode
+*.swp
+*.swo
+*.orig
+*~

--- a/.prettierignore
+++ b/.prettierignore
@@ -62,3 +62,7 @@ typings/
 
 # IDE
 .vscode
+*.swp
+*.swo
+*.orig
+*~


### PR DESCRIPTION
<!--
    Esse doc é um suporte a escrita de PR's e todos os itens são opcionais.
    Utilize, dê feedback e contribua 🎉
-->

#### Qual o problema

<!--
   Escreva uma descrição a respeito das alterações que você está fazendo,
   enumerando os impactos isso tem para o projeto.
-->
Os arquivos `.gitignore` e `.prettierignore` não continham regras para ignorar algumas extensões de arquivos temporários.

#### O que foi feito

<!--
   Escreva aqui mais profundamente como funciona a implementação do que
   este PR abrange.
-->
Foram adicionadas regras para que sejam ignorados arquivos contendo extensões comuns a arquivos temporários.
As extensões adicionadas são algumas das mais utilizadas por editores de texto, IDEs e ferramentas builtin do git.

